### PR TITLE
Redo argument parsing and add `log` subcommand 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 Secure and sleek dosage logging for the terminal.
 
 ## Usage
-`skrive [path to doses.dat]`
+```
+skrive [-f path to doses.dat]
+skrive log [-f path to doses.dat] <quantity> <substance> <route>
+```
+
 
 Skrive selects a path for the doses file in the following order:
 
-1. The path provided as the first argument, as shown above
+1. The path provided with the `-f` flag, as shown above
 2. The path given by the environment variable `SKRIVE_DOSES_PATH`, if set
 3. The path to a file called `doses.dat` in your home directory
     - `~/doses.dat` on Unix-like platforms

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Secure and sleek dosage logging for the terminal.
 ## Usage
 ```
 skrive [-f path to doses.dat]
-skrive log [-f path to doses.dat] <quantity> <substance> <route>
+skrive log [-f path to doses.dat] [<quantity> <substance> <route>]
 ```
 
 

--- a/args.go
+++ b/args.go
@@ -11,23 +11,47 @@ import (
 var subcommand *string
 var parser = argparse.NewParser("skrive", "Log doses via the terminal")
 var fileArg = parser.String("f", "file", &argparse.Options{Required: false, Help: "Set dosage file path"})
+var helpFlag = parser.Flag("h", "help", &argparse.Options{Help: "Print help information"})
+var positionalArguments = []string{}
 
 func parse() error {
-	subcommands := []string{}
+	// Our custom help flag is used for properly called printHelp()
+	parser.DisableHelp()
+	subcommands := []string{"log"}
 
 	var remainingArgs []string
 
 	if len(os.Args) >= 2 && slices.Contains(subcommands, os.Args[1]) {
 		subcommand = &os.Args[1]
-		remainingArgs = os.Args[2:]
-		slices.Insert(remainingArgs, 0, "skrive")
+		remainingArgs = slices.Insert(os.Args[2:], 0, "skrive")
 	} else {
 		remainingArgs = os.Args
 	}
 
-	return parser.Parse(remainingArgs)
+	positionalParameters := [3]*string{}
+
+	if subcommand != nil && *subcommand == "log" {
+		options := argparse.Options{Help: argparse.DisableDescription}
+
+		for i := range positionalParameters {
+			positionalParameters[i] = parser.StringPositional(&options)
+		}
+	}
+
+	var err = parser.Parse(remainingArgs)
+
+	for i := range positionalParameters {
+		if positionalParameters[i] == nil || *positionalParameters[i] == "" {
+			continue
+		}
+		positionalArguments = slices.Insert(positionalArguments, i, *positionalParameters[i])
+	}
+
+	return err
 }
 
 func printHelp(err error) {
+	parser.NewCommand("<blank>", "Open interactive menu")
+	parser.NewCommand("log", "Log a dose")
 	fmt.Print(parser.Usage(err))
 }

--- a/args.go
+++ b/args.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"slices"
+
+	"github.com/akamensky/argparse"
+)
+
+var subcommand *string
+var parser = argparse.NewParser("skrive", "Log doses via the terminal")
+var fileArg = parser.String("f", "file", &argparse.Options{Required: false, Help: "Set dosage file path"})
+
+func parse() error {
+	subcommands := []string{}
+
+	var remainingArgs []string
+
+	if len(os.Args) >= 2 && slices.Contains(subcommands, os.Args[1]) {
+		subcommand = &os.Args[1]
+		remainingArgs = os.Args[2:]
+		slices.Insert(remainingArgs, 0, "skrive")
+	} else {
+		remainingArgs = os.Args
+	}
+
+	return parser.Parse(remainingArgs)
+}
+
+func printHelp(err error) {
+	fmt.Print(parser.Usage(err))
+}

--- a/arguments.go
+++ b/arguments.go
@@ -10,12 +10,14 @@ import (
 
 var subcommand *string
 var parser = argparse.NewParser("skrive", "Log doses via the terminal")
-var fileArg = parser.String("f", "file", &argparse.Options{Required: false, Help: "Set dosage file path"})
+var fileArg = parser.String("f", "file", &argparse.Options{Required: false, Help: "Set the doses file path"})
 var helpFlag = parser.Flag("h", "help", &argparse.Options{Help: "Print help information"})
 var positionalArguments = []string{}
 
 func parse() error {
-	// Our custom help flag is used for properly called printHelp()
+	// Our custom help flag is used for properly displaying usage information
+	// The default behavior does not account for the usage of the subcommands
+	//  defined in printHelp()
 	parser.DisableHelp()
 	subcommands := []string{"log"}
 
@@ -51,7 +53,7 @@ func parse() error {
 }
 
 func printHelp(err error) {
-	parser.NewCommand("<blank>", "Open interactive menu")
+	parser.NewCommand("<blank>", "Open the TUI")
 	parser.NewCommand("log", "Log a dose")
 	fmt.Print(parser.Usage(err))
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbles v0.17.1
 	github.com/charmbracelet/bubbletea v0.25.0
 	github.com/charmbracelet/lipgloss v0.9.1
+	github.com/akamensky/argparse v1.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/akamensky/argparse v1.4.0 h1:YGzvsTqCvbEZhL8zZu2AiA5nq805NZh75JNj4ajn1xc=
+github.com/akamensky/argparse v1.4.0/go.mod h1:S5kwC7IuDcEr5VeXtGPRVZ5o/FdhcMlQz4IZQuw64xA=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=

--- a/log/command.go
+++ b/log/command.go
@@ -1,0 +1,31 @@
+package log
+
+import (
+	"fmt"
+	"os"
+	"skrive/logic"
+	"time"
+)
+
+func Invoke(arguments []string) error {
+	if len(arguments) != 3 {
+		fmt.Println("Must either provide either 0 or 3 separate arguments (quantity, substance, & route)")
+		os.Exit(1)
+	}
+
+	log(arguments[0], arguments[1], arguments[2], 0)
+
+	dose := logic.Dose{
+		Time:      time.Now(),
+		Quantity:  arguments[0],
+		Substance: arguments[1],
+		Route:     arguments[2],
+	}
+
+	if err := dose.Log(); err != nil {
+		return err
+	}
+
+	fmt.Printf("Logged %s of %s, taken via route %s\n", arguments[0], arguments[1], arguments[2])
+	return nil
+}

--- a/logic/logic.go
+++ b/logic/logic.go
@@ -17,9 +17,9 @@ type Dose struct {
 
 var dosageFilePath string
 
-func Setup(fileArgument *string) error {
-	if fileArgument != nil {
-		dosageFilePath = *fileArgument
+func Setup(fileArgument string) error {
+	if len(fileArgument) > 0 {
+		dosageFilePath = fileArgument
 		return nil
 	}
 

--- a/logic/logic.go
+++ b/logic/logic.go
@@ -17,9 +17,9 @@ type Dose struct {
 
 var dosageFilePath string
 
-func Setup() error {
-	if len(os.Args) > 2 {
-		dosageFilePath = os.Args[1]
+func Setup(fileArgument *string) error {
+	if fileArgument != nil {
+		dosageFilePath = *fileArgument
 		return nil
 	}
 

--- a/main.go
+++ b/main.go
@@ -21,8 +21,7 @@ func main() {
 		defer f.Close()
 	}
 
-	parseErr := parse()
-	if parseErr != nil {
+	if parseErr := parse(); parseErr != nil {
 		printHelp(parseErr)
 		os.Exit(1)
 	} else if *helpFlag {
@@ -51,7 +50,7 @@ func main() {
 			Run()
 	}
 
-	handleIfError(err)
+	exitIfError(err)
 }
 
 func handleSubcommands() {
@@ -61,12 +60,12 @@ func handleSubcommands() {
 			// Handled in Bubbletea initialization code
 			return
 		}
-		handleIfError(log.Invoke(positionalArguments))
+		exitIfError(log.Invoke(positionalArguments))
 	}
 	os.Exit(0)
 }
 
-func handleIfError(err error) {
+func exitIfError(err error) {
 	if err == nil {
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -20,7 +20,13 @@ func main() {
 		defer f.Close()
 	}
 
-	err := logic.Setup()
+	parseErr := parse()
+	if parseErr != nil {
+		printHelp(parseErr)
+		os.Exit(1)
+	}
+
+	err := logic.Setup(fileArg)
 
 	if err == nil {
 		_, err = tea.


### PR DESCRIPTION
* Added `argparse` as a new library to handle command line arguments
* Moved specification of the doses file to the new `-f` flag, as opposed to the first argument of the program
* Added the `log` subcommand. Acts as a shortcut with 0 arguments. 
* Added documentation for the above