### PR TITLE
Add support for offsets to the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Secure and sleek dosage logging for the terminal.
 ## Usage
 ```
 skrive [-f path to doses.dat]
-skrive log [-f path to doses.dat] [<quantity> <substance> <route>]
+skrive log [-f path to doses.dat] [<quantity> <substance> <route> [minutes since dose]]
 ```
 
 

--- a/arguments.go
+++ b/arguments.go
@@ -30,7 +30,7 @@ func parse() error {
 		remainingArgs = os.Args
 	}
 
-	positionalParameters := [3]*string{}
+	positionalParameters := [4]*string{}
 
 	if subcommand != nil && *subcommand == "log" {
 		options := argparse.Options{Help: argparse.DisableDescription}

--- a/log/command.go
+++ b/log/command.go
@@ -10,7 +10,9 @@ import (
 
 func Invoke(arguments []string) error {
 	if len(arguments) < 3 && len(arguments) > 4 {
-		fmt.Println("Must either provide either 0, 3 or 4 separate arguments (quantity, substance, route and - optionally - minutes since dose)")
+		fmt.Println("Usage: " +
+			"skrive log [-f path to doses.dat] " +
+			"[<quantity> <substance> <route> [minutes since dose]]")
 		os.Exit(1)
 	}
 

--- a/log/command.go
+++ b/log/command.go
@@ -4,19 +4,33 @@ import (
 	"fmt"
 	"os"
 	"skrive/logic"
+	"strconv"
 	"time"
 )
 
 func Invoke(arguments []string) error {
-	if len(arguments) != 3 {
-		fmt.Println("Must either provide either 0 or 3 separate arguments (quantity, substance, & route)")
+	if len(arguments) < 3 && len(arguments) > 4 {
+		fmt.Println("Must either provide either 0, 3 or 4 separate arguments (quantity, substance, route and - optionally - minutes since dose)")
 		os.Exit(1)
 	}
 
-	log(arguments[0], arguments[1], arguments[2], 0)
+	time := time.Now()
+	offsetDescription := ""
+
+	if len(arguments) > 3 {
+		value, err := strconv.Atoi(arguments[3])
+
+		if err != nil {
+			fmt.Println("Minutes since dose must be an integer!")
+			os.Exit(1)
+		}
+
+		time = timeFromOffset(value)
+		offsetDescription = fmt.Sprintf(" %d minutes ago", value)
+	}
 
 	dose := logic.Dose{
-		Time:      time.Now(),
+		Time:      time,
 		Quantity:  arguments[0],
 		Substance: arguments[1],
 		Route:     arguments[2],
@@ -26,6 +40,12 @@ func Invoke(arguments []string) error {
 		return err
 	}
 
-	fmt.Printf("Logged %s of %s, taken via route %s\n", arguments[0], arguments[1], arguments[2])
+	fmt.Printf(
+		"Logged %s of %s, taken via route %s%s\n",
+		arguments[0],
+		arguments[1],
+		arguments[2],
+		offsetDescription,
+	)
 	return nil
 }

--- a/log/logic.go
+++ b/log/logic.go
@@ -12,10 +12,14 @@ type logMsg struct {
 	success bool
 }
 
+func timeFromOffset(offset int) time.Time {
+	return time.Now().Add(time.Duration(-offset) * time.Minute)
+}
+
 func log(quantity string, substance string, route string, offset int) tea.Cmd {
 	return func() tea.Msg {
 		dose := logic.Dose{
-			Time:      time.Now().Add(time.Duration(-offset) * time.Minute),
+			Time:      timeFromOffset(offset),
 			Quantity:  quantity,
 			Substance: substance,
 			Route:     route,


### PR DESCRIPTION
# Changes
## Offset support
This PR adds the ability to offset doses by a given number of minutes when logging through the CLI. This is done through an optional parameter at the end of the `log` command.

The new usage of the `skrive log` command is as follows;  
`skrive log [-f path to doses.dat] [<quantity> <substance> <route> [minutes since dose]]`

An example of this would be;  
`skrive log '300 mg' Gabapentin Oral 270`  
Which logs a 300 mg oral dose of gabapentin 270 minutes ago.

## Improved documentation
I've altered the error message which is given when an incorrect number of parameters is passed to `skrive log` to give the usage description which is also shown in `README.md`.