### PR TITLE
D-H-M format

### DIFF
--- a/log/popup.go
+++ b/log/popup.go
@@ -8,6 +8,58 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+func increment(raw_before_delimiter *string, field *int) error {
+	val, err := strconv.Atoi(*raw_before_delimiter)
+	*raw_before_delimiter = ""
+
+	if err == nil {
+		*field += val
+	}
+
+	return err
+}
+
+func parseTime(raw string) (int, error) {
+	days := 0
+	hours := 0
+	minutes := 0
+
+	raw_before_delimiter := ""
+
+	for i := range raw {
+		r := raw[i]
+		var err error
+
+		switch r {
+		case 'd':
+			err = increment(&raw_before_delimiter, &days)
+		case 'h':
+			err = increment(&raw_before_delimiter, &hours)
+		case 'm':
+			err = increment(&raw_before_delimiter, &minutes)
+		default:
+			raw_before_delimiter += string(r)
+		}
+
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	if len(raw_before_delimiter) > 0 {
+		err := increment(&raw_before_delimiter, &minutes)
+
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	hours += days * 24
+	minutes += hours * 60
+
+	return minutes, nil
+}
+
 type popupModel struct {
 	input textinput.Model
 }
@@ -34,7 +86,7 @@ func (m popupModel) Update(msg tea.Msg) (*int, *popupModel, tea.Cmd) {
 			return nil, &m, tea.Quit
 		case "enter":
 			raw_value := m.input.Value()
-			value, err := strconv.Atoi(raw_value)
+			value, err := parseTime(raw_value)
 
 			if err != nil {
 				m.input.Prompt = "Minutes since dose:\n(Must be an integer)\n"

--- a/log/popup.go
+++ b/log/popup.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -19,7 +20,19 @@ func increment(raw_before_delimiter *string, field *int) error {
 	return err
 }
 
+type emptyTimeError struct{}
+
+func (e *emptyTimeError) Error() string {
+	return "The time cannot be empty."
+}
+
 func parseTime(raw string) (int, error) {
+	raw = strings.Trim(raw, " ")
+
+	if len(raw) == 0 {
+		return 0, &emptyTimeError{}
+	}
+
 	days := 0
 	hours := 0
 	minutes := 0

--- a/log/popup.go
+++ b/log/popup.go
@@ -89,7 +89,7 @@ func (m popupModel) Update(msg tea.Msg) (*int, *popupModel, tea.Cmd) {
 			value, err := parseTime(raw_value)
 
 			if err != nil {
-				m.input.Prompt = "Minutes since dose:\n(Must be an integer)\n"
+				m.input.Prompt = "Minutes since dose:\n(1d2h3m or 123 (for 123 minutes))\n"
 			} else {
 				return &value, nil, nil
 			}


### PR DESCRIPTION
Allow users to use the D-H-M format when backdating doses.

An example of this is `1d2h3m` for 1 day, 2 hours and 3 minutes.