### PR TITLE
Support new time format in log subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ Secure and sleek dosage logging for the terminal.
 ## Usage
 ```
 skrive [-f path to doses.dat]
-skrive log [-f path to doses.dat] [<quantity> <substance> <route> [minutes since dose]]
+skrive log [-f path to doses.dat] [<quantity> <substance> <route> [time-spec]]
 ```
 
+The log command accepts time formats like `1h30m` or `90` for backdating doses e.g. 90 minutes.
 
 Skrive selects a path for the doses file in the following order:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ skrive [-f path to doses.dat]
 skrive log [-f path to doses.dat] [<quantity> <substance> <route> [time-spec]]
 ```
 
-The log command accepts time formats like `1h30m` or `90` for backdating doses e.g. 90 minutes.
+The log command's time argument can be formatted using either `dhm` formatting or as a number of minutes.  
+For example, 90 minutes can be formatted as follows;
+- `1h30m`
+- `1h30`
+- `90`
 
 Skrive selects a path for the doses file in the following order:
 

--- a/log/command.go
+++ b/log/command.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"skrive/logic"
-	"strconv"
 	"time"
 )
 
@@ -12,7 +11,7 @@ func Invoke(arguments []string) error {
 	if len(arguments) < 3 && len(arguments) > 4 {
 		fmt.Println("Usage: " +
 			"skrive log [-f path to doses.dat] " +
-			"[<quantity> <substance> <route> [minutes since dose]]")
+			"[<quantity> <substance> <route> [time-spec]]")
 		os.Exit(1)
 	}
 
@@ -20,10 +19,10 @@ func Invoke(arguments []string) error {
 	offsetDescription := ""
 
 	if len(arguments) > 3 {
-		value, err := strconv.Atoi(arguments[3])
+		value, err := parseTime(arguments[3])
 
 		if err != nil {
-			fmt.Println("Minutes since dose must be an integer!")
+			fmt.Println("Time argument must be like 1d2h3m or 123 (for 123 minutes)")
 			os.Exit(1)
 		}
 

--- a/log/dhm.go
+++ b/log/dhm.go
@@ -1,0 +1,70 @@
+package log
+
+import (
+	"strconv"
+	"strings"
+)
+
+func increment(raw_before_delimiter *string, field *int) error {
+	val, err := strconv.Atoi(*raw_before_delimiter)
+	*raw_before_delimiter = ""
+
+	if err == nil {
+		*field += val
+	}
+
+	return err
+}
+
+type emptyTimeError struct{}
+
+func (e *emptyTimeError) Error() string {
+	return "The time cannot be empty."
+}
+
+func parseTime(raw string) (int, error) {
+	raw = strings.Trim(raw, " ")
+
+	if len(raw) == 0 {
+		return 0, &emptyTimeError{}
+	}
+
+	days := 0
+	hours := 0
+	minutes := 0
+
+	raw_before_delimiter := ""
+
+	for i := range raw {
+		r := raw[i]
+		var err error
+
+		switch r {
+		case 'd':
+			err = increment(&raw_before_delimiter, &days)
+		case 'h':
+			err = increment(&raw_before_delimiter, &hours)
+		case 'm':
+			err = increment(&raw_before_delimiter, &minutes)
+		default:
+			raw_before_delimiter += string(r)
+		}
+
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	if len(raw_before_delimiter) > 0 {
+		err := increment(&raw_before_delimiter, &minutes)
+
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	hours += days * 24
+	minutes += hours * 60
+
+	return minutes, nil
+}

--- a/log/popup.go
+++ b/log/popup.go
@@ -1,77 +1,10 @@
 package log
 
 import (
-	"strconv"
-	"strings"
-
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
-
-func increment(raw_before_delimiter *string, field *int) error {
-	val, err := strconv.Atoi(*raw_before_delimiter)
-	*raw_before_delimiter = ""
-
-	if err == nil {
-		*field += val
-	}
-
-	return err
-}
-
-type emptyTimeError struct{}
-
-func (e *emptyTimeError) Error() string {
-	return "The time cannot be empty."
-}
-
-func parseTime(raw string) (int, error) {
-	raw = strings.Trim(raw, " ")
-
-	if len(raw) == 0 {
-		return 0, &emptyTimeError{}
-	}
-
-	days := 0
-	hours := 0
-	minutes := 0
-
-	raw_before_delimiter := ""
-
-	for i := range raw {
-		r := raw[i]
-		var err error
-
-		switch r {
-		case 'd':
-			err = increment(&raw_before_delimiter, &days)
-		case 'h':
-			err = increment(&raw_before_delimiter, &hours)
-		case 'm':
-			err = increment(&raw_before_delimiter, &minutes)
-		default:
-			raw_before_delimiter += string(r)
-		}
-
-		if err != nil {
-			return 0, err
-		}
-	}
-
-	if len(raw_before_delimiter) > 0 {
-		err := increment(&raw_before_delimiter, &minutes)
-
-		if err != nil {
-			return 0, err
-		}
-	}
-
-	hours += days * 24
-	minutes += hours * 60
-
-	return minutes, nil
-}
 
 type popupModel struct {
 	input textinput.Model

--- a/skrive.1.man
+++ b/skrive.1.man
@@ -15,7 +15,7 @@ skrive \- Log doses via the terminal
 .I "substance "
 .I "route "
 [ 
-.I "offset-in-minutes"
+.I "TIME-SPEC"
 ]
 ]
 
@@ -34,6 +34,15 @@ Set the file path where doses will be read and written to. This flag takes absol
 .TP
 .B \-h \-\-help
 Display brief usage information.
+
+.SH LOG TIME SPECIFICATION
+.PP
+Both the log TUI and the log subcommand accepts a time offset for backdating doses.
+Skrive accepts a format like 
+.I 1d2h3m
+or
+.I 123
+\[char46] If a plain integer is provided, it will be interpreted as minutes.
 
 .SH "ENVIRONMENT"
 .TP
@@ -60,8 +69,11 @@ Open the TUI to log and view doses.
 Open the TUI and log to
 .I subdir/doses.dat
 .TP
-.B skrive log 2mg Estradiol Sublingual 120
-Immediately log 2mg estradiol sublingually, taken 2 hours ago.
+.B skrive log 2mg Estradiol Sublingual 30
+Immediately log 2mg estradiol sublingually, taken 30 minutes ago.
+.TP
+.B skrive log 2mg Estradiol Sublingual 1h30m
+Immediately log 2mg estradiol sublingually, taken 90 minutes ago.
 .TP
 .B skrive log
 Shortcut to enter a single dose via the TUI before exiting.

--- a/skrive.1.man
+++ b/skrive.1.man
@@ -37,12 +37,18 @@ Display brief usage information.
 
 .SH LOG TIME SPECIFICATION
 .PP
-Both the log TUI and the log subcommand accepts a time offset for backdating doses.
-Skrive accepts a format like 
-.I 1d2h3m
-or
-.I 123
-\[char46] If a plain integer is provided, it will be interpreted as minutes.
+Both the log TUI and the log subcommand accept a time offset for backdating doses.
+.PP
+Skrive accepts both a dhm format and plain integers. For example, for 90 minutes, one can use the following options:
+.br
+\[bu]
+.I 1h30m
+.br
+\[bu]
+.I 1h30
+.br
+\[bu]
+.I 90
 
 .SH "ENVIRONMENT"
 .TP


### PR DESCRIPTION
Support for a new time format was added to the TUI in #11. This adds the same feature in the CLI, and documents it in the readme and manpage.